### PR TITLE
feat: identify users in PostHog with email when logged in

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { ClerkProvider } from "@clerk/nextjs";
 import { Analytics } from "@vercel/analytics/react";
 import { Geist, Geist_Mono } from "next/font/google";
 import { AgentProvider } from "@/lib/agent";
+import { AnalyticsIdentifier } from "@/components/analytics";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -37,6 +38,7 @@ export default function RootLayout({
         <body
           className={`${geistSans.variable} ${geistMono.variable} antialiased`}
         >
+          <AnalyticsIdentifier />
           <AgentProvider>{children}</AgentProvider>
           <Analytics />
         </body>

--- a/src/components/analytics/AnalyticsIdentifier.tsx
+++ b/src/components/analytics/AnalyticsIdentifier.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useUser } from "@clerk/nextjs";
+import { analytics } from "@/lib/analytics";
+
+/**
+ * Component that identifies users in analytics when they sign in.
+ * Must be rendered inside ClerkProvider.
+ * Renders nothing - purely for side effects.
+ */
+export function AnalyticsIdentifier() {
+  const { user, isSignedIn, isLoaded } = useUser();
+  const previousUserId = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!isLoaded) return;
+
+    const currentUserId = isSignedIn && user ? user.id : null;
+
+    // Only identify/reset when user state actually changes
+    if (currentUserId === previousUserId.current) return;
+
+    if (currentUserId && user) {
+      const email = user.emailAddresses[0]?.emailAddress;
+      analytics.identify(currentUserId, {
+        email,
+        name: user.fullName ?? undefined,
+      });
+    } else if (previousUserId.current !== null) {
+      // User signed out - reset analytics identity
+      analytics.reset();
+    }
+
+    previousUserId.current = currentUserId;
+  }, [isLoaded, isSignedIn, user]);
+
+  return null;
+}

--- a/src/components/analytics/__tests__/AnalyticsIdentifier.test.tsx
+++ b/src/components/analytics/__tests__/AnalyticsIdentifier.test.tsx
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, act } from "@testing-library/react";
+import { AnalyticsIdentifier } from "../AnalyticsIdentifier";
+
+// Mock analytics
+const mockIdentify = vi.fn();
+const mockReset = vi.fn();
+
+vi.mock("@/lib/analytics", () => ({
+  analytics: {
+    identify: (...args: unknown[]) => mockIdentify(...args),
+    reset: () => mockReset(),
+  },
+}));
+
+// Mock Clerk's useUser hook
+const mockUseUser = vi.fn();
+vi.mock("@clerk/nextjs", () => ({
+  useUser: () => mockUseUser(),
+}));
+
+describe("AnalyticsIdentifier", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not call identify when auth is loading", () => {
+    mockUseUser.mockReturnValue({
+      isLoaded: false,
+      isSignedIn: false,
+      user: null,
+    });
+
+    render(<AnalyticsIdentifier />);
+
+    expect(mockIdentify).not.toHaveBeenCalled();
+    expect(mockReset).not.toHaveBeenCalled();
+  });
+
+  it("does not call identify or reset when user is not signed in initially", () => {
+    mockUseUser.mockReturnValue({
+      isLoaded: true,
+      isSignedIn: false,
+      user: null,
+    });
+
+    render(<AnalyticsIdentifier />);
+
+    expect(mockIdentify).not.toHaveBeenCalled();
+    expect(mockReset).not.toHaveBeenCalled();
+  });
+
+  it("calls identify with user email when user is signed in", () => {
+    const mockUser = {
+      id: "user_123",
+      fullName: "John Doe",
+      emailAddresses: [{ emailAddress: "john@example.com" }],
+    };
+
+    mockUseUser.mockReturnValue({
+      isLoaded: true,
+      isSignedIn: true,
+      user: mockUser,
+    });
+
+    render(<AnalyticsIdentifier />);
+
+    expect(mockIdentify).toHaveBeenCalledTimes(1);
+    expect(mockIdentify).toHaveBeenCalledWith("user_123", {
+      email: "john@example.com",
+      name: "John Doe",
+    });
+  });
+
+  it("handles user without email gracefully", () => {
+    const mockUser = {
+      id: "user_456",
+      fullName: "Jane Doe",
+      emailAddresses: [],
+    };
+
+    mockUseUser.mockReturnValue({
+      isLoaded: true,
+      isSignedIn: true,
+      user: mockUser,
+    });
+
+    render(<AnalyticsIdentifier />);
+
+    expect(mockIdentify).toHaveBeenCalledWith("user_456", {
+      email: undefined,
+      name: "Jane Doe",
+    });
+  });
+
+  it("handles user without fullName gracefully", () => {
+    const mockUser = {
+      id: "user_789",
+      fullName: null,
+      emailAddresses: [{ emailAddress: "test@example.com" }],
+    };
+
+    mockUseUser.mockReturnValue({
+      isLoaded: true,
+      isSignedIn: true,
+      user: mockUser,
+    });
+
+    render(<AnalyticsIdentifier />);
+
+    expect(mockIdentify).toHaveBeenCalledWith("user_789", {
+      email: "test@example.com",
+      name: undefined,
+    });
+  });
+
+  it("calls reset when user signs out", () => {
+    const mockUser = {
+      id: "user_123",
+      fullName: "John Doe",
+      emailAddresses: [{ emailAddress: "john@example.com" }],
+    };
+
+    mockUseUser.mockReturnValue({
+      isLoaded: true,
+      isSignedIn: true,
+      user: mockUser,
+    });
+
+    const { rerender } = render(<AnalyticsIdentifier />);
+
+    expect(mockIdentify).toHaveBeenCalledTimes(1);
+
+    // User signs out
+    mockUseUser.mockReturnValue({
+      isLoaded: true,
+      isSignedIn: false,
+      user: null,
+    });
+
+    act(() => {
+      rerender(<AnalyticsIdentifier />);
+    });
+
+    expect(mockReset).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not re-identify when user state is unchanged", () => {
+    const mockUser = {
+      id: "user_123",
+      fullName: "John Doe",
+      emailAddresses: [{ emailAddress: "john@example.com" }],
+    };
+
+    mockUseUser.mockReturnValue({
+      isLoaded: true,
+      isSignedIn: true,
+      user: mockUser,
+    });
+
+    const { rerender } = render(<AnalyticsIdentifier />);
+
+    expect(mockIdentify).toHaveBeenCalledTimes(1);
+
+    // Rerender with same user (simulating component re-render)
+    act(() => {
+      rerender(<AnalyticsIdentifier />);
+    });
+
+    // Should not call identify again
+    expect(mockIdentify).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders null (no visible output)", () => {
+    mockUseUser.mockReturnValue({
+      isLoaded: true,
+      isSignedIn: false,
+      user: null,
+    });
+
+    const { container } = render(<AnalyticsIdentifier />);
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/components/analytics/index.ts
+++ b/src/components/analytics/index.ts
@@ -1,0 +1,1 @@
+export { AnalyticsIdentifier } from "./AnalyticsIdentifier";


### PR DESCRIPTION
Add AnalyticsIdentifier component that uses Clerk's useUser hook to
identify users in PostHog when they sign in. The component passes the
user's email and full name to PostHog for user identification, and
resets the identity when users sign out.

https://claude.ai/code/session_01FwDLwf7uVzDukPwLjVBqU5